### PR TITLE
nix-linuxkit-runner: add the missing Security.framework

### DIFF
--- a/nix-linuxkit-runner/default.nix
+++ b/nix-linuxkit-runner/default.nix
@@ -1,0 +1,19 @@
+{ callPackage
+, defaultCrateOverrides
+, Security
+}:
+let
+  needSecurity = attrs: {
+    buildInputs = [ Security ];
+  };
+
+  cargoDeps = callPackage ./Cargo.nix {};
+
+  runner = cargoDeps.nix_linuxkit_runner {};
+in
+  runner.override {
+    crateOverrides = defaultCrateOverrides // {
+      ctrlc = needSecurity;
+      structopt-derive = needSecurity;
+    };
+  }

--- a/overlay.nix
+++ b/overlay.nix
@@ -14,6 +14,10 @@ self: pkgs: {
   go-vpnkit = pkgs.callPackage ./go-vpnkit { };
   linuxkit = pkgs.callPackage ./linuxkit { };
   linuxkit-builder = pkgs.callPackage ./linuxkit-builder { };
-  nix-linuxkit-runner = (pkgs.callPackage ./nix-linuxkit-runner/Cargo.nix { }).nix_linuxkit_runner {};
+
+  nix-linuxkit-runner = pkgs.callPackage ./nix-linuxkit-runner {
+    inherit (pkgs.darwin.apple_sdk.frameworks) Security;
+  };
+
   nix-script-store-plugin = pkgs.callPackage ./nix-script-store-plugin { };
 }


### PR DESCRIPTION
the builds probably started failing once sandboxing was enabled on
Darwin