### PR TITLE
linuxkit-builder: fix make-system-tarball args

### DIFF
--- a/linuxkit-builder/default.nix
+++ b/linuxkit-builder/default.nix
@@ -8,11 +8,10 @@
 
 { system
 , stdenv
-, perl
 , pixz
 , bash
 , nix
-, pathsFromGraph
+, closureInfo
 , hyperkit
 , vpnkit
 , linuxkit
@@ -71,7 +70,7 @@ let
 
   hd = "sda";
   systemTarball = import <nixpkgs/nixos/lib/make-system-tarball.nix> {
-    inherit stdenv perl pixz pathsFromGraph;
+    inherit stdenv closureInfo pixz;
     contents = [];
     storeContents = [
       {


### PR DESCRIPTION
These changed in 19.03: https://github.com/NixOS/nixpkgs/commit/4259f7575e5a715bf4001e22894ce95cdc06385a