### PR TITLE
dont store socket files in the nix store

### DIFF
--- a/linuxkit-builder/default.nix
+++ b/linuxkit-builder/default.nix
@@ -180,16 +180,19 @@ let
       paths = [
         (writeRunitForegroundService "acpid" ''
           #!/bin/sh
+          mkdir -p /var/lib/acpid && cd /var/lib/acpid
           exec ${pkgsForLinux.busybox}/bin/acpid -f
         '')
 
         (writeRunitForegroundService "sshd" ''
           #!/bin/sh
+          mkdir -p /var/lib/sshd && cd /var/lib/sshd
           exec ${pkgsForLinux.openssh}/bin/sshd -D -e -f ${sshdConfig}
         '')
 
         (writeRunitForegroundService "vpnkit-expose-port" ''
           #!/bin/sh
+          mkdir -p /var/lib/vpnkit-expose-port && cd /var/lib/vpnkit-expose-port
 
           ${pkgsForLinux.go-vpnkit}/bin/vpnkit-expose-port \
             -i \
@@ -203,6 +206,7 @@ let
         (writeRunitForegroundService "vpnkit-forwarder" ''
           #!/bin/sh
 
+          mkdir -p /var/lib/vpnkit-forwarder && cd /var/lib/vpnkit-forwarder
           exec ${pkgsForLinux.go-vpnkit}/bin/vpnkit-forwarder
         '')
       ];


### PR DESCRIPTION
Using the nix store to store the state files causes problems when
restarting the guest because socket file types not supported by nix.

I think this should help with #22 